### PR TITLE
[router] Handle Query DELETE api

### DIFF
--- a/internal/router/request_type.go
+++ b/internal/router/request_type.go
@@ -26,6 +26,35 @@ func (r UiRequest) Validate() error {
 	return nil
 }
 
+type QueryApiRequest struct {
+	ClientRequest
+	headerConnectionProperties string
+	headerClientTags           string
+	incomingPort               int32
+	transactionId              string
+	clientHost                 string
+	Query                      *gatewayv1.Query
+}
+
+func (QueryApiRequest) isClientRequest() {}
+func (r QueryApiRequest) Validate() error {
+	tag := "query api"
+	if r.Query.GetUsername() == "" {
+		return fmt.Errorf("%s: %s", tag, "Missing Trino Username header")
+	}
+	if r.Query.GetId() == "" {
+		return fmt.Errorf("%s: %s", tag, "Missing Query Id")
+	}
+
+	// TODO: remove it once transaction support is added
+	// Looker's Presto client sends `X-Presto-Transaction-Id: NONE`
+	// whereas trino client doesnt send it if its not set
+	if !(r.transactionId == "" || r.transactionId == "NONE") {
+		return fmt.Errorf("%s: %s", tag, "Transactions are not supported in gateway.")
+	}
+	return nil
+}
+
 type QueryRequest struct {
 	ClientRequest
 	headerConnectionProperties string

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -152,6 +152,15 @@ func (r *RouterServer) handleClientRequest(ctx *context.Context, req *http.Reque
 					nt.Query.GetBackendId(),
 				).
 				Inc()
+		case *QueryApiRequest:
+			metrics.requestsRoutedTotal.
+				WithLabelValues(
+					req.Method,
+					fmt.Sprint(r.port),
+					nt.Query.GetGroupId(),
+					nt.Query.GetBackendId(),
+				).
+				Inc()
 		default:
 		}
 	}


### PR DESCRIPTION
certain clients like golang currently 
invoke DELETE query api calls for cancelled queries

https://github.com/trinodb/trino-go-client/blob/27054e07bec784f809cd5ddaa8bdacd839a38134/trino/trino.go#L948