### PR TITLE
Fix docker deployment configs

### DIFF
--- a/config/default.toml
+++ b/config/default.toml
@@ -34,7 +34,8 @@
 [gateway]
     ports                 = [8080, 8081]
     defaultRoutingGroup   = "adhoc"
-    network               = "localhost"
+    # empty will mean 0.0.0.0 which is required only if running inside docker container, set to `localhost` otherwise
+    network               = ""
 
 [monitor]
     interval              = "10m"

--- a/config/dev-docker.toml
+++ b/config/dev-docker.toml
@@ -9,4 +9,3 @@
 
 [gateway]
     defaultRoutingGroup          = "dev"
-    network                      = ""


### PR DESCRIPTION
Regression:
Listen to 0.0.0.0 address when running in container