### PR TITLE
[Auth] - Adding Password based authentication

### DIFF
--- a/build/docker/dev/Dockerfile
+++ b/build/docker/dev/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /app
 
 
 RUN apk update \
-    && apk add --no-cache bash make protobuf protobuf-dev git gzip curl
+    && apk add --no-cache bash make protobuf protobuf-dev git gzip curl build-base
 
 # COPY ./ /app
 # RUN go mod download

--- a/build/docker/dev/docker-compose.yml
+++ b/build/docker/dev/docker-compose.yml
@@ -11,6 +11,7 @@ services:
       - ./../../..:/app
     environment:
       APP_ENV: dev-docker
+      TRINO-GATEWAY_AUTH_ROUTER_AUTHENTICATE: true
     entrypoint: /app/build/docker/dev/entrypoint.sh
     # entrypoint: ["tail", "-f", "/dev/null"]
     expose:

--- a/build/docker/prod/Dockerfile
+++ b/build/docker/prod/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /app
 
 
 RUN apk update \
-    && apk add --no-cache bash make protobuf protobuf-dev git gzip curl
+    && apk add --no-cache bash make protobuf protobuf-dev git gzip curl build-base
 
 COPY ./ /app
 

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -109,7 +109,7 @@ func startGatewayServers(_ctx *context.Context) []*http.Server {
 
 	servers := make([]*http.Server, len(boot.Config.Gateway.Ports))
 	for i, port := range boot.Config.Gateway.Ports {
-		server := router.Server(&ctx, port, &gatewayClient, boot.Config.App.ServiceExternalHostname)
+		server := router.Server(&ctx, port, &gatewayClient, boot.Config.App.ServiceExternalHostname, boot.Config.Auth.Router.Authenticate)
 		servers[i] = server
 
 		go listenHttp(&ctx, server, port)

--- a/config/default.toml
+++ b/config/default.toml
@@ -28,8 +28,16 @@
         connectionMaxLifetime = 0
 
 [auth]
-    token              = "test123"
-    tokenHeaderKey     = "X-Auth-Key"
+    token                        = "test123"
+    tokenHeaderKey               = "X-Auth-Key"
+    [auth.router]
+        validationURL            = "localhost:28001"
+        validationToken          = "test123"
+        cacheTTLMinutes          = "10m"
+        authenticate             = false
+
+
+
 
 [gateway]
     ports                 = [8080, 8081]

--- a/go.mod
+++ b/go.mod
@@ -33,6 +33,8 @@ require (
 	gorm.io/plugin/dbresolver v1.1.0
 )
 
+require github.com/stretchr/objx v0.5.0 // indirect
+
 require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -400,6 +400,7 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
+github.com/stretchr/objx v0.5.0 h1:1zr/of2m5FGMsad5YfcqgdqdWrIhu+EBEJRhR1U7z/c=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -29,6 +29,12 @@ type App struct {
 type Auth struct {
 	Token          string
 	TokenHeaderKey string
+	Router         struct {
+		ValidationURL   string
+		ValidationToken string
+		CacheTTLMinutes string
+		Authenticate    bool
+	}
 }
 
 type Gateway struct {

--- a/internal/router/auth.go
+++ b/internal/router/auth.go
@@ -1,0 +1,172 @@
+package router
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/razorpay/trino-gateway/internal/boot"
+	"github.com/razorpay/trino-gateway/internal/provider"
+	"github.com/razorpay/trino-gateway/internal/router/trinoheaders"
+)
+
+type AuthCache struct {
+	Cache map[string]struct {
+		Timestamp time.Time
+		Password  string
+	}
+	mu sync.Mutex
+}
+type AuthService interface {
+	Authenticate(ctx *context.Context, username, password string) (bool, error)
+}
+type DefaultAuthService struct{}
+
+func NewDefaultAuthService() *DefaultAuthService {
+	return &DefaultAuthService{}
+}
+
+/*
+Calls an Auth Token Validator Service with following api contract:
+With Params-
+{
+	"email": "abc@xyz.com",
+	"token": "token123"
+}
+api returns-
+If Authenticated - {"ok": true}
+If not authenticated- {"ok": false}
+
+@returns-
+boolean{True or False},error_message
+*/
+func (s *DefaultAuthService) Authenticate(ctx *context.Context, username string, password string) (bool, error) {
+	authCache, ok := (*ctx).Value("routerAuthCache").(*AuthCache)
+
+	if !ok {
+		authCache = &AuthCache{
+			Cache: make(map[string]struct {
+				Timestamp time.Time
+				Password  string
+			}),
+		}
+		*ctx = context.WithValue(*ctx, "routerAuthCache", authCache)
+	}
+
+	if authCache.Check(username, password) {
+		authCache.Update(username, password)
+		return true, nil
+	}
+	payload := struct {
+		Username string `json:"email"`
+		Token    string `json:"token"`
+	}{
+		Username: username,
+		Token:    password,
+	}
+
+	payloadBytes, _ := json.Marshal(payload)
+	req, _ := http.NewRequest("POST", boot.Config.Auth.Router.ValidationURL, bytes.NewReader(payloadBytes))
+	req.Header.Set("X-Auth-Token", boot.Config.Auth.Router.ValidationToken)
+	req.Header.Set("Content-Type", "application/json")
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return false, err
+	}
+	defer resp.Body.Close()
+
+	respBody, _ := ioutil.ReadAll(resp.Body)
+
+	var data struct {
+		OK bool `json:"ok"`
+	}
+	jsonParseError := json.Unmarshal([]byte(respBody), &data)
+	if jsonParseError != nil {
+		return false, jsonParseError
+	}
+
+	if data.OK {
+		authCache.Update(username, password)
+	}
+
+	return data.OK, nil
+}
+
+func (authCache *AuthCache) Check(username, password string) bool {
+	authCache.mu.Lock()
+	defer authCache.mu.Unlock()
+
+	entry, found := authCache.Cache[username]
+
+	if !found {
+		return false
+	}
+	cachedInterval := boot.Config.Auth.Router.CacheTTLMinutes
+
+	cachedDuration, _ := time.ParseDuration(cachedInterval)
+
+	if time.Since(entry.Timestamp) > cachedDuration {
+		// If entry is older than cachedDuration, then delete the record and return false
+		delete(authCache.Cache, username)
+		return false
+	}
+
+	return entry.Password == password
+}
+
+func (authCache *AuthCache) Update(username, password string) {
+	authCache.mu.Lock()
+	defer authCache.mu.Unlock()
+
+	authCache.Cache[username] = struct {
+		Timestamp time.Time
+		Password  string
+	}{
+		Timestamp: time.Now(),
+		Password:  password,
+	}
+}
+
+func WithAuth(ctx *context.Context, h http.Handler, authService ...AuthService) http.Handler {
+
+	var auth AuthService
+	if len(authService) > 0 {
+		auth = authService[0]
+	} else {
+		auth = NewDefaultAuthService()
+	}
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+
+		username := trinoheaders.Get(trinoheaders.User, r)
+		password := trinoheaders.Get(trinoheaders.Password, r)
+
+		//Remove this later after full rollout
+		if password == "" {
+			h.ServeHTTP(w, r)
+			return
+		}
+
+		isAuthenticated, err := auth.Authenticate(ctx, username, password)
+
+		if err != nil {
+			errorMsg := fmt.Sprintf("Unable to Authenticate users. Getting error - %s", err)
+			provider.Logger(*ctx).Error(errorMsg)
+			http.Error(w, "Unable to Authenticate the user", http.StatusNotFound)
+			return
+		}
+		if !isAuthenticated {
+			provider.Logger(*ctx).Debug(fmt.Sprintf("User - %s not authenticated", username))
+			http.Error(w, "User not authenticated", http.StatusUnauthorized)
+			return
+		}
+
+		h.ServeHTTP(w, r)
+	})
+}

--- a/internal/router/auth_test.go
+++ b/internal/router/auth_test.go
@@ -1,0 +1,247 @@
+package router_test
+
+import (
+	"context"
+	"errors"
+	r "github.com/razorpay/trino-gateway/internal/router"
+	"github.com/stretchr/testify/mock"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+)
+
+type MockAuthenticator struct {
+	mock.Mock
+}
+
+// A mock struct that implements the AuthService interface
+type AuthServiceMock struct {
+	authMock *MockAuthenticator
+}
+type AuthCache struct {
+	cache map[string]struct {
+		Timestamp time.Time
+		Password  string
+	}
+	mu sync.Mutex
+}
+
+func createContextWithHeaders() context.Context {
+	// Create a context with a value for routerAuthCache
+	ctx := context.WithValue(context.Background(), "routerAuthCache", &AuthCache{
+		cache: make(map[string]struct {
+			Timestamp time.Time
+			Password  string
+		}),
+	})
+	return ctx
+}
+
+func createTestRequestWithHeaders(username, password string) *http.Request {
+	req := httptest.NewRequest("GET", "/test", nil)
+	req.Header.Set("X-Trino-User", username)
+	req.Header.Set("X-Trino-Password", password)
+	return req
+}
+
+func (m *AuthServiceMock) Authenticate(ctx *context.Context, username string, password string) (bool, error) {
+	args := m.authMock.Called(ctx, username, password)
+	return args.Bool(0), args.Error(1)
+}
+
+func Test_WithAuth_Authorised(t *testing.T) {
+	authMock := &MockAuthenticator{}
+	ctx := createContextWithHeaders()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}
+
+	authMock.On("Authenticate", &ctx, "testuser", "testpassword").Return(true, nil)
+
+	authService := &AuthServiceMock{authMock}
+
+	wrappedHandler := r.WithAuth(&ctx, http.HandlerFunc(handler), authService)
+
+	req := createTestRequestWithHeaders("testuser", "testpassword")
+
+	rr := httptest.NewRecorder()
+
+	wrappedHandler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Errorf("Expected status code %d, got %d", http.StatusOK, rr.Code)
+	}
+
+	authMock.AssertExpectations(t)
+}
+
+func Test_WithAuth_UnAuthorised(t *testing.T) {
+	authMock := &MockAuthenticator{}
+	ctx := createContextWithHeaders()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}
+
+	authMock.On("Authenticate", &ctx, "testuser", "testpassword").Return(false, nil)
+
+	authService := &AuthServiceMock{authMock}
+
+	wrappedHandler := r.WithAuth(&ctx, http.HandlerFunc(handler), authService)
+
+	req := createTestRequestWithHeaders("testuser", "testpassword")
+
+	rr := httptest.NewRecorder()
+
+	wrappedHandler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusUnauthorized {
+		t.Errorf("Expected status code %d, got %d", http.StatusUnauthorized, rr.Code)
+	}
+
+	authMock.AssertExpectations(t)
+}
+
+func Test_WithAuth_Error(t *testing.T) {
+	authMock := &MockAuthenticator{}
+	ctx := createContextWithHeaders()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}
+
+	authMock.On("Authenticate", &ctx, "testuser", "testpassword").Return(false, errors.New("authentication failed"))
+
+	authService := &AuthServiceMock{authMock}
+
+	wrappedHandler := r.WithAuth(&ctx, http.HandlerFunc(handler), authService)
+
+	req := createTestRequestWithHeaders("testuser", "testpassword")
+
+	rr := httptest.NewRecorder()
+
+	wrappedHandler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusNotFound {
+		t.Errorf("Expected status code %d, got %d", http.StatusNotFound, rr.Code)
+	}
+
+	authMock.AssertExpectations(t)
+}
+
+func Test_Check_ValidCredentials_WithinCache(t *testing.T) {
+	// Create an instance of AuthCache
+
+	authCache := &r.AuthCache{
+		Cache: make(map[string]struct {
+			Timestamp time.Time
+			Password  string
+		}),
+	}
+	//r.AuthCache{authCache}
+	// Define test credentials
+	username := "testuser"
+	password := "testpassword"
+
+	// Add a test entry to the cache
+	entry := struct {
+		Timestamp time.Time
+		Password  string
+	}{
+		Timestamp: time.Now(),
+		Password:  password,
+	}
+	authCache.Cache[username] = entry
+	valid := authCache.Check(username, password)
+
+	// Assert that the check method returns true for valid credentials
+	if !valid {
+		t.Error("Expected valid credentials, but got invalid credentials")
+	}
+}
+
+func Test_Check_ValidCredentials_NotCached(t *testing.T) {
+	// Create an instance of AuthCache
+
+	authCache := &r.AuthCache{
+		Cache: make(map[string]struct {
+			Timestamp time.Time
+			Password  string
+		}),
+	}
+	//r.AuthCache{authCache}
+	// Define test credentials
+	username := "testuser"
+	password := "testpassword"
+
+	// Add a test entry to the cache
+	entry := struct {
+		Timestamp time.Time
+		Password  string
+	}{
+		Timestamp: time.Now().Add(-15 * time.Minute),
+		Password:  password,
+	}
+	authCache.Cache[username] = entry
+	valid := authCache.Check(username, password)
+
+	// Assert that the check method returns true for valid credentials
+	if valid {
+		t.Error("Expected expired credentials, but got valid credentials")
+	}
+}
+
+func Test_Check_InValidCredentials_WithinCache(t *testing.T) {
+	// Create an instance of AuthCache
+
+	authCache := &r.AuthCache{
+		Cache: make(map[string]struct {
+			Timestamp time.Time
+			Password  string
+		}),
+	}
+	//r.AuthCache{authCache}
+	// Define test credentials
+	username := "testuser"
+	password := "testpassword"
+
+	// Add a test entry to the cache
+	entry := struct {
+		Timestamp time.Time
+		Password  string
+	}{
+		Timestamp: time.Now(),
+		Password:  password,
+	}
+	authCache.Cache[username] = entry
+
+	wrongpassword := "falsepassword"
+	valid := authCache.Check(username, wrongpassword)
+
+	// Assert that the check method returns true for valid credentials
+	if valid {
+		t.Error("Expected Invalid credentials, but got valid credentials")
+	}
+}
+
+func Test_Update(t *testing.T) {
+	authCache := &r.AuthCache{
+		Cache: make(map[string]struct {
+			Timestamp time.Time
+			Password  string
+		}),
+	}
+	authCache.Update("testUser", "testPassword")
+
+	expectedPassword := "testPassword"
+	if entry, exists := authCache.Cache["testUser"]; exists {
+		if entry.Password != expectedPassword {
+			t.Errorf("Password for 'testUser' is not as expected. Got: %s, Expected: %s", entry.Password, expectedPassword)
+		}
+	} else {
+		t.Errorf("Entry for 'testUser' not found in the cache")
+	}
+}

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -54,7 +54,7 @@ func init() {
 	initMetrics()
 }
 
-func Server(ctx *context.Context, port int, apiClient *GatewayApiClient, routerHostname string) *http.Server {
+func Server(ctx *context.Context, port int, apiClient *GatewayApiClient, routerHostname string, authenticate bool) *http.Server {
 	routerServer := RouterServer{
 		port:             port,
 		gatewayApiClient: apiClient,
@@ -108,9 +108,17 @@ func Server(ctx *context.Context, port int, apiClient *GatewayApiClient, routerH
 		},
 	}
 
-	return &http.Server{
-		Handler: &reverseProxy,
+	if authenticate {
+		authenticatedReverseProxy := WithAuth(ctx, &reverseProxy)
+		return &http.Server{
+			Handler: authenticatedReverseProxy,
+		}
+	} else {
+		return &http.Server{
+			Handler: &reverseProxy,
+		}
 	}
+
 }
 
 func (r *RouterServer) extractSharedRequestCtxObject(ctx *context.Context, req *http.Request) (*ContextSharedObject, error) {

--- a/internal/router/trinoheaders/trino.go
+++ b/internal/router/trinoheaders/trino.go
@@ -13,6 +13,7 @@ const (
 	ClientTags           = "Client-Tags"
 	ConnectionProperties = "Connection-Properties"
 	TransactionId        = "Transaction-Id"
+	Password             = "Password"
 )
 
 var allowedPrefixes = [...]string{"Presto", "Trino"}


### PR DESCRIPTION
Adding support for password based authentication to trino-gateway.

Enabled in-memory caching-
Mechanism: If a user is active in last 10 minutes then its authentication will be served via in-memory cache, else it will be routed to datum for verification.