### PR TITLE
[DE-5182] (agent-ready): add live routing topology inspection commands

### DIFF
--- a/.agents/skills/repo-skill/modules/integration/external-deps.md
+++ b/.agents/skills/repo-skill/modules/integration/external-deps.md
@@ -218,3 +218,49 @@ What trino-gateway calls, how it connects, and what happens when things break.
 | Auth validation provider (slow) | Runtime | Proxy requests hang indefinitely (no timeout) |
 | Prometheus | Runtime | No impact on gateway operation |
 | Self loopback API | Runtime | Monitor cannot update backends; Router cannot resolve routes |
+
+---
+
+## 6. Production Routing Topology — How to Inspect
+
+The gateway runs as a single deployment with multiple named ports. Each port has a dedicated K8s Service and Traefik IngressRoute. Routing decisions are stored in the gateway's MySQL database, not in K8s config.
+
+### Querying Live State
+
+**Backends** (which Trino clusters are registered):
+```bash
+curl -s -X POST 'https://trino-gateway-admin.de.razorpay.com/twirp/razorpay.gateway.BackendApi/ListAllBackends' \
+  -H 'Content-Type: application/json' -d '{}'
+```
+
+**Groups** (which backends are in each routing group + strategy):
+```bash
+curl -s -X POST 'https://trino-gateway-admin.de.razorpay.com/twirp/razorpay.gateway.GroupApi/ListAllGroups' \
+  -H 'Content-Type: application/json' -d '{}'
+```
+
+**Policies** (which port routes to which group):
+```bash
+curl -s -X POST 'https://trino-gateway-admin.de.razorpay.com/twirp/razorpay.gateway.PolicyApi/ListAllPolicies' \
+  -H 'Content-Type: application/json' -d '{}'
+```
+
+**K8s IngressRoutes** (which hostnames map to which service/port):
+```bash
+kubectl get ingressroute -n trino-gateway
+kubectl get svc -n trino-gateway   # shows service → targetPort mapping
+```
+
+### Routing Chain
+
+The full chain is: **IngressRoute (hostname) → K8s Service → container port → Policy (port→group) → Group (strategy→backend) → Backend (Trino cluster hostname)**
+
+### Key Patterns
+
+- Each gateway port (8080-8091) has a dedicated K8s Service and IngressRoute — port assignments are fixed in prod config (`config/prod.toml`)
+- Backend hostnames use `-int.de.razorpay.com` (internal) for actual routing; `external_url` is for UI redirect rewriting only
+- Scheduler backends may use cluster-local DNS (`.svc.cluster.local`) instead of Traefik ingress
+- Looker clusters use blue/green pattern — multiple backends registered but only one enabled at a time
+- `concierge` suffix in IngressRoute names = external access via concierge proxy
+- Querybook connects directly to Trino clusters — NOT routed through the gateway
+- Auth delegation is per-policy — check the `is_auth_delegated` field in policy response

--- a/.agents/skills/repo-skill/modules/integration/service-contracts.md
+++ b/.agents/skills/repo-skill/modules/integration/service-contracts.md
@@ -193,3 +193,32 @@ Metrics are registered in:
 | External auth provider (`ValidationProviderURL`) | Users not in the in-memory cache cannot authenticate on delegated-auth ports. Cached users continue to work until TTL expires. |
 | Trino backend cluster | Proxy returns 502 Bad Gateway. Gateway itself stays healthy. Monitoring marks backend unhealthy. |
 | Twirp API (localhost) from proxy | Proxy cannot route any requests -- policy evaluation, backend resolution all fail. Returns 400 or 502 to clients. |
+
+---
+
+## 6. K8s Exposure — How to Inspect
+
+The gateway exposes itself via Traefik IngressRoutes in the `trino-gateway` namespace. To see current state:
+
+```bash
+# List all IngressRoutes with their host matching rules
+kubectl get ingressroute -n trino-gateway -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.spec.routes[0].match}{"\n"}{end}'
+
+# List services with target ports (maps service → gateway container port)
+kubectl get svc -n trino-gateway -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.spec.ports[0].targetPort}{"\n"}{end}'
+
+# Admin API (Swagger UI)
+# https://trino-gateway-admin.de.razorpay.com/admin/swaggerui/
+```
+
+### Naming Conventions
+
+- `-int.de.razorpay.com` = internal (VPN access)
+- `.de.razorpay.com` without `-int` = concierge (external proxy access)
+- `router-{name}` in service name = gateway proxy port for that workload type
+- `trino-gateway-app` = Twirp management API (port 8000)
+
+### Not Routed Through Gateway
+
+- **Querybook** connects directly to Trino clusters
+- **Airflow** uses a gateway port (8082) but has no IngressRoute — only reachable cluster-internally

--- a/.agents/skills/repo-skill/modules/integration/service-contracts.md
+++ b/.agents/skills/repo-skill/modules/integration/service-contracts.md
@@ -206,10 +206,17 @@ kubectl get ingressroute -n trino-gateway -o jsonpath='{range .items[*]}{.metada
 
 # List services with target ports (maps service → gateway container port)
 kubectl get svc -n trino-gateway -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.spec.ports[0].targetPort}{"\n"}{end}'
-
-# Admin API (Swagger UI)
-# https://trino-gateway-admin.de.razorpay.com/admin/swaggerui/
 ```
+
+### Admin API (Swagger UI)
+
+| Environment | URL |
+|-------------|-----|
+| Prod | `https://trino-gateway-admin.de.razorpay.com/admin/swaggerui/` |
+| Prod (dev config) | `https://trino-dev-gateway-admin.de.razorpay.com/admin/swaggerui/` |
+| Stage | Check IngressRoutes in stage cluster: `kubectl get ingressroute -n trino-gateway --context <stage-context>` |
+
+The admin hostname pattern is `trino-{env}-gateway-admin.de.razorpay.com`. Exact hostnames vary per cluster — always verify from IngressRoutes.
 
 ### Naming Conventions
 
@@ -217,8 +224,3 @@ kubectl get svc -n trino-gateway -o jsonpath='{range .items[*]}{.metadata.name}{
 - `.de.razorpay.com` without `-int` = concierge (external proxy access)
 - `router-{name}` in service name = gateway proxy port for that workload type
 - `trino-gateway-app` = Twirp management API (port 8000)
-
-### Not Routed Through Gateway
-
-- **Querybook** connects directly to Trino clusters
-- **Airflow** uses a gateway port (8082) but has no IngressRoute — only reachable cluster-internally


### PR DESCRIPTION
Replace static routing tables with API/kubectl commands agents can use to query live state: backends, groups, policies, IngressRoutes.